### PR TITLE
Add upstream proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ python3 evilwaf.py -t https://target.com --enable-tor
 Headless Mode (No TUI)
 python3 evilwaf.py -t https://target.com --no-tui
 
+Upstream Proxy (route through external proxy)
+python3 evilwaf.py -t https://target.com --upstream-proxy socks5://127.0.0.1:1080
+python3 evilwaf.py -t https://target.com --upstream-proxy http://user:pass@proxy.com:8080
+python3 evilwaf.py -t https://target.com --proxy-file proxies.txt
+
 Custom Listen Address and Port
 python3 evilwaf.py -t https://target.com --listen-host 0.0.0.0 --listen-port 9090
 

--- a/chemistry/proxy_rotator.py
+++ b/chemistry/proxy_rotator.py
@@ -1,0 +1,124 @@
+import socket
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+import socks
+
+
+@dataclass
+class ProxyRotator:
+    proxy_urls: List[str] = field(default_factory=list)
+
+    _proxies: List[Dict] = field(default_factory=list, init=False, repr=False)
+    _current_index: int = field(default=0, init=False, repr=False)
+    _lock: object = field(default=None, init=False, repr=False)
+    _rotation_counter: int = field(default=0, init=False, repr=False)
+
+    SCHEME_MAP = {
+        "socks5": socks.SOCKS5,
+        "socks5h": socks.SOCKS5,
+        "socks4": socks.SOCKS4,
+        "socks4a": socks.SOCKS4,
+        "http": socks.HTTP,
+        "https": socks.HTTP,
+    }
+
+    def __post_init__(self):
+        self._lock = threading.Lock()
+        parsed = [self._parse_proxy_url(u) for u in self.proxy_urls]
+        self._proxies = [p for p in parsed if p is not None]
+        alive = self._probe_proxies()
+        if alive:
+            self._proxies = alive
+
+    def _parse_proxy_url(self, url: str) -> Optional[Dict]:
+        try:
+            p = urlparse(url)
+            scheme = (p.scheme or "socks5").lower()
+            proxy_type = self.SCHEME_MAP.get(scheme)
+            if proxy_type is None:
+                return None
+            port = p.port or (1080 if scheme.startswith("socks") else 8080)
+            return {
+                "type": proxy_type,
+                "addr": p.hostname,
+                "port": port,
+                "username": p.username,
+                "password": p.password,
+                "url": url,
+                "scheme": scheme,
+            }
+        except Exception:
+            return None
+
+    def _probe_proxies(self) -> List[Dict]:
+        alive = []
+        for proxy in self._proxies:
+            try:
+                s = socks.create_connection(
+                    dest_pair=("check.torproject.org", 443),
+                    timeout=10,
+                    proxy_type=proxy["type"],
+                    proxy_addr=proxy["addr"],
+                    proxy_port=proxy["port"],
+                    proxy_username=proxy.get("username"),
+                    proxy_password=proxy.get("password"),
+                )
+                s.close()
+                alive.append(proxy)
+            except Exception:
+                continue
+        return alive
+
+    def _next_proxy(self) -> Optional[Dict]:
+        with self._lock:
+            if not self._proxies:
+                return None
+            proxy = self._proxies[self._current_index % len(self._proxies)]
+            self._current_index += 1
+            self._rotation_counter += 1
+            return proxy
+
+    def create_connection(self, dest_host: str, dest_port: int, timeout: int = 15) -> socket.socket:
+        proxy = self._next_proxy()
+        if proxy is None:
+            sock = socket.create_connection((dest_host, dest_port), timeout=timeout)
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            return sock
+        sock = socks.create_connection(
+            dest_pair=(dest_host, dest_port),
+            timeout=timeout,
+            proxy_type=proxy["type"],
+            proxy_addr=proxy["addr"],
+            proxy_port=proxy["port"],
+            proxy_username=proxy.get("username"),
+            proxy_password=proxy.get("password"),
+            socket_options=[(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],
+        )
+        return sock
+
+    def get_proxy_dict(self) -> Dict[str, str]:
+        proxy = self._next_proxy()
+        if proxy is None:
+            return {}
+        url = proxy["url"]
+        return {"http": url, "https": url}
+
+    def per_request_proxy(self) -> Dict:
+        proxy = self._next_proxy()
+        if proxy is None:
+            return {"proxies": {}, "rotation_count": self._rotation_counter}
+        url = proxy["url"]
+        return {
+            "proxies": {"http": url, "https": url},
+            "rotation_count": self._rotation_counter,
+        }
+
+    def get_stats(self) -> Dict:
+        return {
+            "available_proxies": len(self._proxies),
+            "rotation_count": self._rotation_counter,
+            "current_index": self._current_index,
+        }

--- a/core/interceptor.py
+++ b/core/interceptor.py
@@ -48,6 +48,7 @@ except ImportError:
 from chemistry.tcp_options import TCPOptionsManipulator
 from chemistry.tls_rotator import TLSFingerprinter
 from chemistry.tor_rotator import TorRotator
+from chemistry.proxy_rotator import ProxyRotator
 
 
 @dataclass
@@ -587,9 +588,11 @@ class TLSContextFactory:
 
 class MITMHandshaker:
     """we use override_ip to force tool to pass body direct to server ip not through web """
-    def __init__(self, ca: CertificateAuthority, override_ip: Optional[str] = None):
+    def __init__(self, ca: CertificateAuthority, override_ip: Optional[str] = None,
+                 proxy_rotator: Optional[ProxyRotator] = None):
         self.ca          = ca
         self.override_ip = override_ip
+        self._proxy_rotator = proxy_rotator
 
     def perform(self, client_sock: socket.socket, hostname: str, port: int) -> Dict[str, Any]:
         result: Dict[str, Any] = {
@@ -608,8 +611,11 @@ class MITMHandshaker:
             client_tls = server_ctx.wrap_socket(client_sock, server_side=True)
 
             connect_host = self.override_ip if self.override_ip else hostname
-            server_raw   = socket.create_connection((connect_host, port), timeout=15)
-            server_raw.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            if self._proxy_rotator:
+                server_raw = self._proxy_rotator.create_connection(connect_host, port, timeout=15)
+            else:
+                server_raw = socket.create_connection((connect_host, port), timeout=15)
+                server_raw.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
             client_alpn   = client_tls.selected_alpn_protocol() or "http/1.1"
             upstream_alpn = ["h2", "http/1.1"] if client_alpn == "h2" and H2_AVAILABLE else ["http/1.1"]
@@ -1143,6 +1149,7 @@ class Interceptor:
         tor_rotate_every: int = 5,
         override_ip: Optional[str] = None,
         target_host: Optional[str] = None,
+        upstream_proxies: Optional[List[str]] = None,
     ):
         self._host = listen_host
         self._port = listen_port
@@ -1153,8 +1160,10 @@ class Interceptor:
         self._records: List[ProxyRecord] = []
         self._records_lock = threading.Lock()
 
+        self._proxy_rotator = ProxyRotator(proxy_urls=upstream_proxies) if upstream_proxies else None
+
         self.ca = CertificateAuthority()
-        self._handshaker = MITMHandshaker(self.ca)
+        self._handshaker = MITMHandshaker(self.ca, proxy_rotator=self._proxy_rotator)
         self._forwarder = Forwarder()
 
         self._tor = TorRotator(
@@ -1185,6 +1194,13 @@ class Interceptor:
     def _is_waf_block(self, code: int) -> bool:
         return code in {403, 406, 407, 409, 418, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526}
 
+    def _create_upstream_connection(self, host: str, port: int, timeout: int = 15) -> socket.socket:
+        if self._proxy_rotator:
+            return self._proxy_rotator.create_connection(host, port, timeout)
+        sock = socket.create_connection((host, port), timeout=timeout)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        return sock
+
     def _process_http_request(self, req: InterceptedRequest) -> InterceptedResponse:
         resp = InterceptedResponse(timestamp=time.time())
         start = time.time()
@@ -1200,8 +1216,7 @@ class Interceptor:
             req.host = host
             req.port = port
 
-            sock = socket.create_connection((host, port), timeout=30)
-            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            sock = self._create_upstream_connection(host, port, timeout=30)
 
             if parsed.scheme == "https":
                 ctx = TLSContextFactory.client_context(alpn=["http/1.1"])
@@ -1406,7 +1421,7 @@ class Interceptor:
                     else:
                         interceptor_ref.https_errors += 1
                         try:
-                            remote_sock = socket.create_connection((remote_host, remote_port), timeout=15)
+                            remote_sock = interceptor_ref._create_upstream_connection(remote_host, remote_port, timeout=15)
                             interceptor_ref.https_tunneled += 1
                             interceptor_ref._handle_tunnel(self.request, remote_sock)
                             try:
@@ -1421,7 +1436,7 @@ class Interceptor:
                         return
 
                 try:
-                    remote_sock = socket.create_connection((remote_host, remote_port), timeout=15)
+                    remote_sock = interceptor_ref._create_upstream_connection(remote_host, remote_port, timeout=15)
                     self.send_response(200, "Connection Established")
                     self.send_header("Proxy-Agent", "EvilWAF")
                     self.end_headers()
@@ -1479,7 +1494,8 @@ def create_interceptor(
     tor_password: str = "",
     tor_rotate_every: int = 5,
     override_ip: Optional[str] = None,
-    target_host: Optional[str] = None,   
+    target_host: Optional[str] = None,
+    upstream_proxies: Optional[List[str]] = None,
 ) -> Interceptor:
     return Interceptor(
         listen_host=listen_host,
@@ -1488,7 +1504,8 @@ def create_interceptor(
         tor_control_port=tor_control_port,
         tor_password=tor_password,
         tor_rotate_every=tor_rotate_every,
-        override_ip=override_ip, # use server ip
+        override_ip=override_ip,
         target_host=target_host,
+        upstream_proxies=upstream_proxies,
     )    
     

--- a/evilwaf.py
+++ b/evilwaf.py
@@ -360,6 +360,7 @@ class EvilWAFTUI:
         server_ip:  Optional[str] = None,
         waf_name:   Optional[str] = None,
         enable_tor: bool = False,
+        upstream_proxy_count: int = 0,
     ):
         self.server      = server
         self.target_url  = target_url
@@ -368,6 +369,7 @@ class EvilWAFTUI:
         self.server_ip   = server_ip
         self.waf_name    = waf_name
         self.enable_tor  = enable_tor
+        self.upstream_proxy_count = upstream_proxy_count
 
         self.traffic_data: List[ProxyRecord] = []
         self.selected_row  = 0
@@ -522,9 +524,10 @@ class EvilWAFTUI:
         waf_p  = f" | WAF: {self.waf_name}" if self.waf_name else ""
         ip_p   = f" | Origin: {self.server_ip}" if self.server_ip else ""
         tor_p  = " | TOR: ON" if self.enable_tor else ""
+        proxy_p = f" | Proxy: {self.upstream_proxy_count}" if self.upstream_proxy_count else ""
         return urwid.AttrMap(
             urwid.Text(
-                ('header', f" EvilWAF v2.4 | {h}{waf_p}{ip_p}{tor_p}   q=Quit  up/down=browse  f=follow "),
+                ('header', f" EvilWAF v2.4 | {h}{waf_p}{ip_p}{tor_p}{proxy_p}   q=Quit  up/down=browse  f=follow "),
                 align='center',
             ),
             'header',
@@ -736,6 +739,7 @@ class EvilWAFOrchestrator:
         tor_rotate_every: int,
         server_ip:        Optional[str] = None,
         target_host:      Optional[str] = None,
+        upstream_proxies: Optional[List[str]] = None,
     ):
         self._enable_tor = enable_tor
         self._running    = False
@@ -749,6 +753,7 @@ class EvilWAFOrchestrator:
             tor_rotate_every=tor_rotate_every,
             override_ip=server_ip,
             target_host=target_host,
+            upstream_proxies=upstream_proxies,
         )
 
         self._tor_table  = TorIPTable()
@@ -839,6 +844,8 @@ def main():
             "  --tor-rotate-every     Rotate TOR IP every N requests (default: 1)\n"
             "  --server-ip            Force all requests to this origin IP (WAF bypass)\n"
             "  --auto-hunt            Auto-discover origin IP behind WAF\n"
+            "  --upstream-proxy URL   Upstream proxy (http://, socks5://, socks4://)\n"
+            "  --proxy-file FILE      File with proxy URLs for rotation\n"
             "  --no-tui               Headless mode, print traffic to stdout\n"
             "\n"
             "API Keys (optional, set as environment variables):\n"
@@ -863,6 +870,10 @@ def main():
     parser.add_argument("--tor-rotate-every",      type=int, default=1)
     parser.add_argument("--server-ip",             type=str, default=None)
     parser.add_argument("--auto-hunt",             action="store_true")
+    parser.add_argument("--upstream-proxy",        type=str, default=None, metavar="URL",
+                        help="Upstream proxy URL (http://host:port, socks5://host:port)")
+    parser.add_argument("--proxy-file",            type=str, default=None, metavar="FILE",
+                        help="File with proxy URLs, one per line, for rotation")
     parser.add_argument("--no-tui",                action="store_true")
 
     args = parser.parse_args()
@@ -878,6 +889,14 @@ def main():
     if args.server_ip and args.auto_hunt:
         print("[!] --server-ip and --auto-hunt cannot be used together")
         sys.exit(1)
+
+    upstream_proxies = None
+    if args.upstream_proxy:
+        upstream_proxies = [args.upstream_proxy]
+    if args.proxy_file:
+        with open(args.proxy_file) as f:
+            file_proxies = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+        upstream_proxies = (upstream_proxies or []) + file_proxies
 
     print("[*] EvilWAF v2.4")
     print(f"[*] Target : {args.target}")
@@ -907,6 +926,9 @@ def main():
     if args.enable_tor:
         print("[*] TOR    : Enabled — rotating IP every request")
 
+    if upstream_proxies:
+        print(f"[*] Proxy  : {len(upstream_proxies)} upstream proxy(ies)")
+
     print(f"[*] Listen : {args.listen_host}:{args.listen_port}")
 
     orchestrator = EvilWAFOrchestrator(
@@ -918,6 +940,7 @@ def main():
         tor_rotate_every=args.tor_rotate_every,
         server_ip=server_ip,
         target_host=parsed.hostname,
+        upstream_proxies=upstream_proxies,
     )
 
     orchestrator.start()
@@ -962,6 +985,7 @@ def main():
                 server_ip=server_ip,
                 waf_name=waf_name,
                 enable_tor=args.enable_tor,
+                upstream_proxy_count=len(upstream_proxies) if upstream_proxies else 0,
             )
             tui.start()
     except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ hpack>=4.0.0
 hyperframe>=6.0.1
 aioquic>=1.0.0
 stem>=1.8.2
+PySocks>=1.7.1
 urwid>=2.1.2
 asyncio>=3.4.3
 dnspython>=2.6.0


### PR DESCRIPTION
## Summary

Fixes #2

Adds upstream proxy support so EvilWAF can route traffic through external HTTP, SOCKS4, and SOCKS5 proxies — enabling IP rotation and additional anonymity layers during WAF bypass testing.

## Changes

- **`chemistry/proxy_rotator.py`** (new) — `ProxyRotator` class with round-robin proxy rotation, health checking, and support for HTTP/SOCKS4/SOCKS5 protocols via PySocks
- **`core/interceptor.py`** — Integrated `ProxyRotator` into the request pipeline so upstream connections route through configured proxies
- **`evilwaf.py`** — Added `--upstream-proxy` (single proxy) and `--proxy-file` (multi-proxy rotation from file) CLI flags
- **`requirements.txt`** — Added `PySocks` dependency
- **`README.md`** — Documented new proxy flags and usage examples

## Usage

```bash
# Single upstream proxy
python3 evilwaf.py -t https://target.com --upstream-proxy socks5://127.0.0.1:1080

# Proxy rotation from file
python3 evilwaf.py -t https://target.com --proxy-file proxies.txt
```

Proxy file format (one per line):
```
http://proxy1:8080
socks5://user:pass@proxy2:1080
socks4://proxy3:1080
```