### PR TITLE
fix: add py_modules=['evilwaf'] to setup.py so main module is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/matrixleons/evilwaf",
     license="Apache-2.0",
+    py_modules=["evilwaf"],
     packages=find_packages(exclude=["tests*", "media*"]),
     ext_modules=[fast_scanner_ext],
     python_requires=">=3.8",


### PR DESCRIPTION
### Problem

`pip install` only installs the `chemistry/` and `core/` packages because `setup.py` uses `find_packages()` without including the top-level `evilwaf.py` module. This causes the `evilwaf` CLI entry point to fail:

```
ModuleNotFoundError: No module named 'evilwaf'
```

### Fix

Add `py_modules=["evilwaf"]` in `setup.py` so the root `evilwaf.py` module is included in the installation.

### Diff

Only **1 line** added:

```diff
+    py_modules=["evilwaf"],
     packages=find_packages(exclude=["tests*", "media*"]),
```

### Verification

```bash
pip install -e .
evilwaf --help  # ✅ works
python -c "import evilwaf"  # ✅ works
```